### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Ex:
     {% endfor %}
 </ul>
 <button class="pay-button">Abrir modal de pagamento</button>
-{% show_pagarme payment_item customer open_modal %}
+{% show_pagarme payment_item customer address open_modal %}
 
 </body>
 </html>


### PR DESCRIPTION
A template tag `show_pagarme` passou a receber um terceiro parâmetro `address`, a não inclusão do mesmo pode causar um erro na validação realizada pelo checkout do pagarme.